### PR TITLE
hl-assets: add visualizer assets to precompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 cache/*
 uploads/*
+public/assets/

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( glvis.css visualizer.js )


### PR DESCRIPTION
rails would crash on the visualize page unless i did this :/

i think it's because the stylesheet helper called from the `<head>` now hooks into the asset pipeline

http://stackoverflow.com/questions/23673036/asset-filtered-out-and-will-not-be-served