### PR TITLE
Gemfile: update json gem to 1.8.6 so it can compile with Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,4 @@ gem 'uglifier'
 gem 'jquery-rails'
 
 gem 'monadic'
+gem 'json', '~> 1.8.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.4)
     less (2.6.0)
       commonjs (~> 0.2.7)
@@ -189,6 +189,7 @@ DEPENDENCIES
   coffee-rails
   config
   jquery-rails
+  json (~> 1.8.5)
   less-rails
   monadic
   omniauth-google-oauth2
@@ -207,4 +208,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.12.5
+   1.15.2


### PR DESCRIPTION
See thread here: https://github.com/rails/rails/issues/27450

An alternate fix is to update Rails, but it's a bigger change.