### PR TITLE
app: send_file with an audio/mpeg type so that safari audio tags can pick it up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
 
     if Settings.use_xsendfile
       head :x_accel_redirect => "/#{ path }",
-           :content_type => "application/octet-stream",
+           :content_type => Mime::Type.lookup_by_extension(opts[:type]),
            :content_disposition => "attachment; filename=\"#{opts[:filename]}\""
     else
       super

--- a/app/controllers/mixtapes_controller.rb
+++ b/app/controllers/mixtapes_controller.rb
@@ -105,7 +105,7 @@ class MixtapesController < ApplicationController
 
     @mixtape.cache_or_zip
 
-    send_file @mixtape.cache_path, :filename => @mixtape.filename, :disposition => 'attachment'
+    send_file @mixtape.cache_path, :filename => @mixtape.filename, :disposition => 'attachment', :type => :zip
   end
 
   def download_all
@@ -122,7 +122,7 @@ class MixtapesController < ApplicationController
       end
     end
 
-    send_file cache_path, :filename => "FriendsOfJack2017Mixes.zip", :disposition => 'attachment'
+    send_file cache_path, :filename => "FriendsOfJack2017Mixes.zip", :disposition => 'attachment', :type => :zip
   end
 
   def listen

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -84,7 +84,7 @@ class SongsController < ApplicationController
 
   def listen
     song = Song.find(params[:id])
-    send_file song.file, :filename => song.filename
+    send_file song.file, :filename => song.filename, :type => :mpeg
   end
 
   def favorites

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,3 +3,5 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 # Mime::Type.register_alias "text/html", :iphone
+Mime::Type.register "audio/mpeg", :mpeg
+Mime::Type.register "application/octet-stream", :zip


### PR DESCRIPTION
From experimentation, it seems that both desktop and mobile Safari will refuse to play URLs that resolve in non-`audio/mpeg` MIME types.

I did this through Rails' weird MIME registration system. I'm not sure why it exists but I suppose it's ... exactly for this situation? I also went through usages of `send_file` and attached MIMEs. The only other one is ZIPs (which I'm keeping at octet-stream).

By the way, audio/mpeg is the wrong mime type for M4As but it doesn't seem like Safari cares.

I verified that this restored audio playback on macOS Sierra and, with the help of ngrok, iOS 10.